### PR TITLE
Add time delay to accommodate apps with client-side JS

### DIFF
--- a/main.go
+++ b/main.go
@@ -5,6 +5,7 @@ import (
 	"net/url"
 	"os"
 	"strings"
+	"time"
 
 	todotests "github.com/yale-cpsc-213/social-todo-selenium-tests/tests"
 )
@@ -30,7 +31,7 @@ func main() {
 	if len(os.Args) >= 4 && strings.Contains(os.Args[3], "fast") {
 		failFast = true
 	}
-	todotests.RunForURL(os.Args[1], os.Args[2], failFast, 1)
+	todotests.RunForURL(os.Args[1], os.Args[2], failFast, time.Millisecond * 500)
 }
 
 func isValidURL(u string) bool {


### PR DESCRIPTION
Time delay is necessary to pass tests for apps which employ client-side JS (e.g React). Time delay (500 ms) chosen to allow time for correct app to consistently pass all tests.